### PR TITLE
PhantomJS install support for gzip

### DIFF
--- a/provision.py
+++ b/provision.py
@@ -40,7 +40,7 @@ APT_DEPENDENCIES = {
         "ca-certificates",      # Explicit dependency in case e.g. wget is already installed
         "puppet",               # Used by lint-all
         "gettext",              # Used by makemessages i18n
-    ]
+    ],
 }
 
 VENV_PATH="/srv/zulip-venv"


### PR DESCRIPTION
Somehow on Windows with Cygwin, when executing "vagrant up" terminal says PhantomJS downloaded as a bzip2 file, yet provisions.py crashes when attempting to install the file. This is fixed by using try/catch to try to install as a bzip2 file and catch an error and then try to install as a gzip file. Now "vagrant up" crashes later instead. Also  changed "jQuery" -> "jquery" to get rid of deprecation warning. 