### PR TITLE
"npm install" support for windows

### DIFF
--- a/provision.py
+++ b/provision.py
@@ -76,6 +76,8 @@ REPO_STOPWORDS_PATH = os.path.join(
 
 LOUD = dict(_out=sys.stdout, _err=sys.stderr)
 
+NO_SYMB_LINKS = "--no-bin-links"
+
 
 def main():
     log = logging.getLogger("zulip-provisioner")
@@ -168,7 +170,7 @@ def main():
     # npm install and management commands expect to be run from the root of the project.
     os.chdir(ZULIP_PATH)
 
-    sh.npm.install(**LOUD)
+    sh.npm.install(NO_SYMB_LINKS, **LOUD)
 
     os.system("tools/download-zxcvbn")
     os.system("tools/emoji_dump/build_emoji")


### PR DESCRIPTION
Added "--no-bin-links" to "npm install" command to support "vagrant up" command while setting up dev environment on Windows. "--no-bin-links" stops symbolic linking, which is not supported on Windows and causes "npm install" to crash.