### PR TITLE
Symbolic linking support in VirtualBox (Mac, Windows)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,7 +30,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  config.vm.provider "virtualbox" do |vb, override|
+  config.vm.provider "virtualbox" do |v,vb, override|
+    v.customize ["setextradata", :id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/v-root", "1"]
     override.vm.box = "ubuntu/trusty64"
     # 2GiB seemed reasonable here. The VM OOMs with only 1024MiB.
     vb.memory = 2048


### PR DESCRIPTION
 This patch allows symbolic linking in VirtualBox shared folders, which is not the default. Shared folders are the default type of synced folder for VirtualBox users: "If you're using the VirtualBox provider, then VirtualBox shared folders are the default synced folder type." (docs.vagrantup.com/v2/synced-folders/virtualbox.html).
